### PR TITLE
Update readme for "build" part of the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,10 +234,10 @@ The default `version` setter accepts these types:
 Version format: `major.minor.patch-build`.
 
 The build part is adjusted only when present. If you have a `1.0.0` version, the `-build` part won't be appended unless
-already present, or you've called the task with `build` argument:
+already present, or you've called the task with `prerelease` argument:
 
 ```shell
-grunt bumpup:build
+grunt bumpup:prerelease
 ```
 
 ## Usage Examples

--- a/tasks/bumpup.js
+++ b/tasks/bumpup.js
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
 		if (typeof release === 'string') {
 			release = release.toLowerCase();
 			if (!/^(major|minor|patch|prerelease)$/i.test(release)) {
-				failed(null, '"' + release + '" is not a valid release type: major, minor, patch, or build.');
+				failed(null, '"' + release + '" is not a valid release type: major, minor, patch, or prerelease.');
 				return;
 			}
 		} else {


### PR DESCRIPTION
Change bumpup:build to bumpup:prerelease in readme and task failure message.

bumpup:build > bumpup:prerelease
