### PR TITLE
add support for setting build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,8 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 
 	// Registering the testing task.
-	grunt.registerTask('test', function (type) {
+	grunt.registerTask('test', function (type, build) {
+		grunt.config.set('build', build);
 		type = type ? type : 'patch';
 		grunt.task.run('logver');
 		grunt.task.run('bumpup:' + type);

--- a/tasks/bumpup.js
+++ b/tasks/bumpup.js
@@ -58,7 +58,7 @@ module.exports = function(grunt) {
 		// Normalize the release type
 		if (typeof releaseType === 'string') {
 			releaseType = releaseType.toLowerCase();
-			if (!/^(major|minor|patch|prerelease)$/i.test(releaseType) && !semver.valid(releaseType)) {
+			if (!/^(major|minor|patch|prerelease|build)$/i.test(releaseType) && !semver.valid(releaseType)) {
 				failed(null, '"' + releaseType + '" is not a valid release type, or a semantic version.');
 				return;
 			}
@@ -93,7 +93,15 @@ module.exports = function(grunt) {
 					grunt.log.warn('Version "' + old + '" is not a valid semantic version.');
 					return;
 				} else {
-					return semver.inc(oldVersion, type);
+					if (type === 'build') {
+						// strip previous build from oldVersion
+						var mainAndPre = oldVersion.split('+')[0],
+								build = grunt.config('build') || 'build0';
+						// add new build from config
+						return mainAndPre + '+' + build;
+					} else {
+						return semver.inc(oldVersion, type);
+					}
 				}
 			},
 			date: function (old, type, o) {


### PR DESCRIPTION
I'd like to set the build portion of the version for continuous integration. `node-semver` has [a concept of build](https://github.com/isaacs/node-semver/blob/master/semver.js#L288) but does not expose any way to interact with it. I tried to mimic [their regex](https://github.com/isaacs/node-semver/blob/master/semver.js#L91-L97) to identify the build portion of the version.

Usage:

``` bash
grunt release:build:$BUILD_NUMBER
```

`$BUILD_NUMBER` would be an environmental variable set by the CI server or could easily just be a timestamp. 

This is just a first pass and would appreciate feedback :smiley: 
